### PR TITLE
Fix REST path to workitems

### DIFF
--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -8,7 +8,7 @@ import { WorkItem } from './work-item';
 @Injectable()
 export class WorkItemService {
   // private workItemUrl = 'app/workItems';  // URL to web api
-  private workItemUrl = 'http://localhost:8080/api/workitem';  // URL to web api
+  private workItemUrl = 'http://localhost:8080/api/workitems';  // URL to web api
 
   constructor(private http: Http) { }
 


### PR DESCRIPTION
In https://github.com/almighty/almighty-core/issues/97 we've changed the core to list workitems under `/api/workitems` (notice the "s" at the end). The docker container of almighty-core is not using this at the moment but we try to get it in there as quick as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/12)
<!-- Reviewable:end -->
