### PR TITLE
Add body property in header for expected empty body

### DIFF
--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -30,7 +30,7 @@ export class WorkItemService {
   delete(workItem: WorkItem): Promise<void> {
     const url = `${this.workItemUrl}/${workItem.id}`;
     return this.http
-      .delete(url, {headers: this.headers})
+      .delete(url, {headers: this.headers, body: ""})
       .toPromise()
       .then(() => null)
       .catch(this.handleError);


### PR DESCRIPTION
Why?
- Usually delete requests are returned with empty body
- Angular's http goes mad when it gets an empty body as response

What? 
- It needs to be told by adding body property in the header and specify it as empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/21)
<!-- Reviewable:end -->
