### PR TITLE
Set environment variables in dev and prod config files

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,7 +1,16 @@
+var webpack = require('webpack');
 var webpackMerge = require('webpack-merge');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var commonConfig = require('./webpack.common.js');
 var helpers = require('./helpers');
+
+const ENV = process.env.ENV = process.env.NODE_ENV = 'development';
+const API_URL = process.env.API_URL = 'http://localhost:8080/api/';
+
+const METADATA = webpackMerge(commonConfig.metadata, {
+  API_URL: API_URL,
+  ENV: ENV
+});
 
 module.exports = webpackMerge(commonConfig, {
   devtool: 'cheap-module-eval-source-map',
@@ -15,7 +24,24 @@ module.exports = webpackMerge(commonConfig, {
   },
 
   plugins: [
-    new ExtractTextPlugin('[name].css')
+    new ExtractTextPlugin('[name].css'),
+
+    /**
+     * Plugin: DefinePlugin
+     * Description: Define free variables.
+     * Useful for having development builds with debug logging or adding global constants.
+     *
+     * Environment helpers
+     *
+     * See: https://webpack.github.io/docs/list-of-plugins.html#defineplugin
+     */
+    // NOTE: when adding more properties, make sure you include them in custom-typings.d.ts
+    new webpack.DefinePlugin({
+      'process.env': {
+        'ENV': JSON.stringify(METADATA.ENV),
+        'API_URL' : JSON.stringify(METADATA.API_URL)
+      }
+    })
   ],
 
   devServer: {

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -5,6 +5,12 @@ var commonConfig = require('./webpack.common.js');
 var helpers = require('./helpers');
 
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
+const API_URL = process.env.API_URL = 'http://localhost:8080/api/';
+
+const METADATA = webpackMerge(commonConfig.metadata, {
+  API_URL: API_URL,
+  ENV: ENV
+});
 
 module.exports = webpackMerge(commonConfig, {
   devtool: 'source-map',
@@ -27,7 +33,8 @@ module.exports = webpackMerge(commonConfig, {
     new ExtractTextPlugin('[name].[hash].css'),
     new webpack.DefinePlugin({
       'process.env': {
-        'ENV': JSON.stringify(ENV)
+        'ENV': JSON.stringify(ENV),
+        'API_URL' : JSON.stringify(METADATA.API_URL)
       }
     })
   ]

--- a/src/app/login/login.service.ts
+++ b/src/app/login/login.service.ts
@@ -8,7 +8,7 @@ import { LoginItem } from './login-item';
 @Injectable()
 export class LoginService {
   // private githubUrl = 'app/loginStatus';
-  private githubUrl = 'http://localhost:8080/api/login/authorize ';  // URL to web api
+  private githubUrl = process.env.API_URL+'login/authorize ';  // URL to web api
 
 
   constructor(private http: Http) { }

--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -9,7 +9,7 @@ import { WorkItem } from './work-item';
 export class WorkItemService {
   private headers = new Headers({'Content-Type': 'application/json'});
   // private workItemUrl = 'app/workItems';  // URL to web api
-  private workItemUrl = 'http://localhost:8080/api/workitems';  // URL to web api
+  private workItemUrl = process.env.API_URL+'workitems';  // URL to web api
   // private workItemUrl = 'http://demo.almighty.io/api/workitems';  // URL to web api
 
   constructor(private http: Http) { }


### PR DESCRIPTION
Request from @kwk - "Can you configure the api endpoint of the core to be read from environment variables? Just as a hack so that we can have it in master and use that branch instead of some other branch?"
Based on https://github.com/AngularClass/angular2-webpack-starter/wiki/How-to-pass-environment-variables%3F - Updated the webpack.dev.js and webpack.prod.js files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/31)
<!-- Reviewable:end -->
