### PR TITLE
A drawer for change status added

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { WorkItemListComponent } from './work-item/work-item-list/work-item-list
 import { WorkItemQuickAddComponent } from './work-item/work-item-quick-add/work-item-quick-add.component';
 import { WorkItemSearchComponent } from './work-item/work-item-search/work-item-search.component';
 import { WorkItemService } from './work-item/work-item.service';
+import { StatusDrawerComponent } from './shared-component/status-drawer.component';
 
 @NgModule({
   imports: [
@@ -44,7 +45,8 @@ import { WorkItemService } from './work-item/work-item.service';
     WorkItemDetailComponent,
     WorkItemQuickAddComponent,
     WorkItemListComponent,
-    WorkItemSearchComponent
+    WorkItemSearchComponent,
+	StatusDrawerComponent
   ],
   providers: [
     Logger,

--- a/src/app/shared-component/status-drawer.component.css
+++ b/src/app/shared-component/status-drawer.component.css
@@ -1,0 +1,35 @@
+.status{
+  width: 130px;
+  text-align: left;
+}
+
+.status span.label{
+  border-radius: 10px;
+  padding: 5px 20px;
+  opacity: 0.7;
+  cursor: pointer;
+}
+
+.drawer {
+	position: absolute;
+	z-index: 100;
+	margin-top: 10px;
+	height: auto;
+	background-color: rgb(243, 231, 231);
+	border-radius: 7px;
+	padding-left: 10px;
+	padding-right: 10px;
+
+}
+
+.drawer li{
+	list-style: none;
+	font-size: 12px;
+	text-align: left;
+	cursor: pointer;
+}
+
+.drawer li:hover{
+	font-weight: 600;
+}
+

--- a/src/app/shared-component/status-drawer.component.html
+++ b/src/app/shared-component/status-drawer.component.html
@@ -1,0 +1,18 @@
+						
+<div *ngIf="workItem" class="status">
+	<span 
+		class="label" 
+		(click)="onDrawerToggle()"
+		[ngClass]="{'label-warning': workItem.statusCode==0, 
+					'label-primary': workItem.statusCode==1, 
+					'label-success': workItem.statusCode==2 }">
+		
+		{{workItem.status ? workItem.status : "Status"}}
+	</span>
+	<ul *ngIf="show" class="drawer">
+		<li (click)="changeStatus(0,'To Do')">To Do</li>
+		<li (click)="changeStatus(1,'In Progress')">In Progress</li>
+		<li (click)="changeStatus(2,'Done')">Done</li>
+	</ul>
+</div>
+

--- a/src/app/shared-component/status-drawer.component.ts
+++ b/src/app/shared-component/status-drawer.component.ts
@@ -1,0 +1,35 @@
+import { 
+	Component, 
+	OnInit, 
+	Input 
+} from '@angular/core';
+
+import { WorkItem } from './../work-item/work-item';
+
+
+@Component({
+	selector   : 'status-drawer',
+	templateUrl: './status-drawer.component.html',
+	styleUrls  : ['src/app/shared-component/status-drawer.component.css'],
+})
+export class StatusDrawerComponent implements OnInit{
+	@Input() workItem: WorkItem;
+	show: boolean = false;
+	
+	ngOnInit(): void {
+		if(!this.workItem.hasOwnProperty("statusCode")){
+			this.workItem.statusCode = 0;
+			this.workItem.status = "To Do";
+		}
+  	}
+
+	onDrawerToggle(): void {
+		this.show = !this.show;
+	}
+
+	changeStatus(code: number, status: string): void {
+		this.workItem.statusCode = code;
+		this.workItem.status = status;
+		this.onDrawerToggle();
+	}
+}

--- a/src/app/work-item/work-item-list/work-item-list.component.css
+++ b/src/app/work-item/work-item-list/work-item-list.component.css
@@ -1,15 +1,6 @@
 .screen-min-ht{
   min-height: 85%;
 }
-.status{
-  width: 130px;
-  text-align: left;
-}
-.status span.label{
-  border-radius: 10px;
-  padding: 5px 20px;
-  opacity: 0.7;
-}
 .type span{
   font-size: 12px;
   margin-right: 10px;

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -22,9 +22,8 @@
 					</div>
 				</div>
 				<div class="list-view-pf-main-info">
-					<div class="list-view-pf-left status">
-						<!--<span class="label" [ngClass]="{'label-warning': workItem.statusCode==0, 'label-primary': workItem.statusCode==1, 'label-success': workItem.statusCode==2 }">{{workItem.status}}</span>-->
-						<span class="label label-warning">{{workItem.status ? workItem.status : "Status"}}</span>
+					<div class="list-view-pf-left">
+						<status-drawer [workItem]="workItem"></status-drawer>						
 					</div>
 					<div class="list-view-pf-left type">
 						<!--<span class='fa' [ngClass]="{'fa-bookmark': workItem.workItemType=='story', 'fa-bug':workItem.workItemType=='bug'}"></span>-->


### PR DESCRIPTION
Why?
 - There is a status label on every work list item.
 - Clicking on that label should give a drawer to select and change status.

What?
 - This is a component which can be used in various places for a work item.
 - It takes workItem as a parameter.
 - Currently it's built based on some static data.
 - The backend is not prepared for showing and changing status yet.

Future planning:
 - We can fetch different types of status and their colors from a backend endpoint.
 - Based on the statusCode from a workItem we show it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/33)
<!-- Reviewable:end -->
