### PR TITLE
the nmp install barfs over a missing bzip2

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -9,7 +9,7 @@ ENV ALMIGHTY_USER_NAME=almighty
 RUN useradd -s /bin/bash ${ALMIGHTY_USER_NAME}
 
 # Install node and wait-for-it.sh script
-RUN yum install -y wget \
+RUN yum install -y wget bzip2\
     && wget --quiet -O /tmp/node.tar.xz https://nodejs.org/download/release/v6.3.1/node-v6.3.1-linux-x64.tar.xz \
     && wget --quiet -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
     && mkdir /usr/local/node \


### PR DESCRIPTION
This might no longer be needed, but as a data point, the npm install was failing unable to unpact a bzip2 archieve.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/38)
<!-- Reviewable:end -->
