### PR TITLE
Fixing styleUrls whitespace issue is status drawer component

### DIFF
--- a/src/app/shared-component/status-drawer.component.ts
+++ b/src/app/shared-component/status-drawer.component.ts
@@ -8,9 +8,9 @@ import { WorkItem } from './../work-item/work-item';
 
 
 @Component({
-	selector   : 'status-drawer',
+	selector: 'status-drawer',
 	templateUrl: './status-drawer.component.html',
-	styleUrls  : ['src/app/shared-component/status-drawer.component.css'],
+	styleUrls: ['./status-drawer.component.css'],
 })
 export class StatusDrawerComponent implements OnInit{
 	@Input() workItem: WorkItem;


### PR DESCRIPTION
Why?
- Absolute path for css file was given as the value of styleUrls
- Not the best way to do it and the relative URL should be used
- Using relative url with a whitespace in between 'styleUrls' and ':' was throwing an exception.

What?
- Either we have to give an absolute URL if we use a white space between 'styleUrls' and ':'
- Or we can use a relative URL without the space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/46)
<!-- Reviewable:end -->
