### PR TITLE
Possibel fix for the production build.

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -16,7 +16,7 @@ const METADATA = webpackMerge(commonConfig.metadata, {
 });
 
 module.exports = webpackMerge(commonConfig, {
-  devtool: 'source-map',
+  devtool: 'eval',
 
   output: {
     path: helpers.root('dist'),

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,4 +8,6 @@ import { Component } from '@angular/core';
   styleUrls: ['/app.component.scss']
   })
 export class AppComponent {
+  constructor(){    
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,1 +1,1 @@
-module.exports = require('./config/webpack.dev.js');
+module.exports = require('./config/webpack.prod.js');


### PR DESCRIPTION
1. Point to production in webpack.config.js
2. Uglify throws an error for devtool set as source-map. Based on https://github.com/webpack/webpack/issues/1385 changed it to eval.
3. After adding a constructor to app.component.ts, the production build succeeded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/55)
<!-- Reviewable:end -->
