### PR TITLE
Listentry as component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { HeaderComponent} from './header/header.component';
 import { LoginComponent} from './login/login.component';
 import { WorkItemDetailComponent } from './work-item/work-item-detail/work-item-detail.component';
 import { WorkItemListComponent } from './work-item/work-item-list/work-item-list.component';
+import { WorkItemListEntryComponent } from './work-item/work-item-list/work-item-list-entry.component';
 import { WorkItemQuickAddComponent } from './work-item/work-item-quick-add/work-item-quick-add.component';
 import { WorkItemSearchComponent } from './work-item/work-item-search/work-item-search.component';
 import { WorkItemService } from './work-item/work-item.service';
@@ -48,6 +49,7 @@ if (process.env.ENV=='inmemory')
     WorkItemDetailComponent,
     WorkItemQuickAddComponent,
     WorkItemListComponent,
+    WorkItemListEntryComponent,
     WorkItemSearchComponent,
 	StatusDrawerComponent
   ],

--- a/src/app/in-memory-data.service.ts
+++ b/src/app/in-memory-data.service.ts
@@ -2,20 +2,12 @@ import { InMemoryDbService } from 'angular2-in-memory-web-api';
 export class InMemoryDataService implements InMemoryDbService {
   createDb() {
     let workitems = [
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},"id": "21", "name": 'Bullet Chart', description: 'Bullet Chart - Conceptual Design',"workItemType":"1","version":0 , status:'To Do', statusCode:0, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 22, name: 'New Account', description: 'Create a New Account',"workItemType":"1","version":0 , status:'In Progress',statusCode:1, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 23, name: 'Login page', description: 'Login page should recognize when caps lock is on and throw a warning message',"workItemType":"1","version":0 , status:'Done',statusCode:2, type: 'bug'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 24, name: 'Splitter', description: 'Splitter - Expand/Collapse snap control',"workItemType":"1","version":0 ,status:'To Do',statusCode:0, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 25, name: 'Integrate', description: 'Integrate PatternFly UI elements',"workItemType":"1","version":0 ,status:'In Progress',statusCode:1, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 26, name: 'Log Viewer', description: 'Log Viewer - Conceptual Design',"workItemType":"1","version":0 ,status:'To Do',statusCode:0, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 13, name: 'Bootstrap', description: 'PatternFly and Bootstrap 4',"workItemType":"1","version":0 ,status:'Done',statusCode:2, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 14, name: 'Travis', description: 'Investigate Travis CI Integration',"workItemType":"1","version":0 ,status:'Done',statusCode:2, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 15, name: 'Links', description: 'Broken Links',"workItemType":"1","version":0 ,status:'Done',statusCode:2, type: 'bug'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 16, name: 'Best Practice', description: 'Code Organization and Best Practice',"workItemType":"1","version":0 ,status:'To Do',statusCode:0, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 17, name: 'Max Width', description: 'Max Width Container',"workItemType":"1","version":0 ,status:'Done',statusCode:2, type: 'bug'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 18, name: 'Font', description: 'Improve Font Weight Management Across Less File',"workItemType":"1","version":0 ,status:'In Progress',statusCode:1, type: 'story'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 19, name: 'Color', description: 'Improve Color Management',"workItemType":"1","version":0 ,status:'In Progress',statusCode:1, type: 'bug'},
-      {"fields":{"system.owner":"tmaeder","system.state":"open"},id: 20, name: 'Empty State', description: 'Empty State - Additional Layout Example',"workItemType":"1","version":0 ,status:'To Do',statusCode:0, type: 'bug'}
+
+      {"fields":{"system.assignee":"someUser1","system.creator":"someOtherUser1","system.description":"Some Description 1","system.state":"new","system.title":"Some Title 1"},"id":"1","type":"system.userstory","version":1},
+      {"fields":{"system.assignee":"someUser2","system.creator":"someOtherUser2","system.description":"Some Description 2","system.state":"open","system.title":"Some Title 2"},"id":"2","type":"system.bug","version":1},
+      {"fields":{"system.assignee":"someUser3","system.creator":"someOtherUser3","system.description":"Some Description 3","system.state":"closed","system.title":"Some Title 3"},"id":"3","type":"system.userstory","version":1},
+      {"fields":{"system.assignee":"someUser4","system.creator":"someOtherUser4","system.description":"Some Description 4","system.state":"resolved","system.title":"Some Title 4"},"id":"4","type":"system.bug","version":1},
+      {"fields":{"system.assignee":"someUser5","system.creator":"someOtherUser5","system.description":"Some Description 5","system.state":"rejected","system.title":"Some Title 5"},"id":"5","type":"system.userstory","version":1}
     ];
 
     let loginStatus = {

--- a/src/app/work-item/work-item-list/work-item-list-entry.component.html
+++ b/src/app/work-item/work-item-list/work-item-list-entry.component.html
@@ -1,0 +1,42 @@
+
+<div class="list-group-item" (click)="onSelect($event)" [class.selected]="isSelected()">
+	<!-- info area -->
+	<div class="list-view-pf-main-info">
+		<div class="list-view-pf-left">
+			<status-drawer [workItem]="workItem"></status-drawer>						
+		</div>
+		<div class="list-view-pf-left type">
+			<span class='fa' [ngClass]="{'fa-wrench': workItem.type=='system.bug',
+										 'fa-user': workItem.type=='system.userstory',
+										 'fa-globe': workItem.type=='system.feature',
+										 'fa-bookmark': workItem.type=='system.experience' }">
+			</span>
+			{{workItem.id}}
+		</div>
+		<div class="list-view-pf-body">
+			<div class="list-view-pf-description">
+				<div class="list-group-item-heading">
+					{{workItem.fields['system.title']}}
+				</div>
+				<div class="list-group-item-text">
+					{{workItem.fields['system.description'] ? workItem.fields['system.description'] : "No description available for this work item."}}
+				</div>
+			</div>
+		</div>
+	</div>
+	<!-- action area -->
+	<div class="list-view-pf-actions">
+		<button class="btn btn-default" (click)="onDetail($event)">View Details</button>
+		<button class="btn btn-default delete-button" (click)="onDelete($event)">Delete</button>
+		<div class="dropdown pull-right dropdown-kebab-pf" [class.open]="actionDropdownOpen">
+			<button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" (click)="onToggleActionDropdown($event)" aria-haspopup="true" aria-expanded="true">
+				<span class="fa fa-ellipsis-v"></span>
+			</button>
+			<ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">
+				<li><a href="#" (click)="onDelete($event)">Delete</a></li>
+				<li><a href="#" (click)="onMoveToBacklog($event)">Move to Backlog</a></li>
+				<li><a href="#" (click)="onChangeState($event)">Change State</a></li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/src/app/work-item/work-item-list/work-item-list-entry.component.scss
+++ b/src/app/work-item/work-item-list/work-item-list-entry.component.scss
@@ -1,0 +1,20 @@
+.type span{
+  font-size: 12px;
+  margin-right: 10px;
+  color: #8b8d8f;
+}
+.work-item-details{
+	padding: 1% 8%;
+}
+.list-group-item {
+  cursor: pointer;
+}
+.selected {
+  background-color: #ededed;;
+}
+button:active:focus {
+  outline: none; 
+}
+button:active, span:focus {
+  outline: none; 
+}

--- a/src/app/work-item/work-item-list/work-item-list-entry.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list-entry.component.ts
@@ -1,0 +1,104 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Router } from "@angular/router";
+
+import { Logger } from '../../shared/logger.service';
+import { WorkItem } from '../work-item';
+import { WorkItemService } from '../work-item.service';
+
+/*
+    Work Item List Entry Component - Displays a work item and action elements for it.
+
+    Inputs: workItem:WorkItem - the WorkItem to be displayed.
+    Events: selectEvent(WorkItemListEntryComponent) - Entry is selected.        
+            detailEvent(WorkItemListEntryComponent) - Detail view for entry is requested.
+            deleteEvent(WorkItemListEntryComponent) - Signals deletion (see note below!).
+
+    Note: all navigational events are delegated to a parent component:
+    detailEvent, selectEvent. The parent component has the obligation to manually call
+    select() on this component! Why? Because this allows the parent component to customize
+    the select behaviour (like multi-selects or xor selects).
+
+    All data events (deleteEvent only currently) are done inside this component (the service
+    is called to delete the workItem) and an event is delegated back to the parent for 
+    information purposes. The parent MUST NOT delete the workItem associated. The event is
+    intended for display purposes, like removing the entry element and reloading the list.
+*/
+
+@Component({
+  selector: 'work-item-list-entry',
+  templateUrl: '/work-item-list-entry.component.html',
+  styleUrls: ['/work-item-list-entry.component.scss'],
+})
+export class WorkItemListEntryComponent {
+  
+  @Input() workItem: WorkItem;
+  @Output() selectEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
+  @Output() detailEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
+  @Output() deleteEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
+
+  selected: boolean = false;
+  actionDropdownOpen: boolean = false;
+
+  constructor(
+    private router: Router,
+    private workItemService: WorkItemService,
+    private logger: Logger) {
+  }
+
+  getWorkItem(): WorkItem {
+    return this.workItem;
+  }
+
+  select(): void {
+    event.stopPropagation();
+    this.selected = true;
+  }
+
+  deselect(): void {
+    console.log("DESELECT " + this.workItem.id);
+    this.actionDropdownOpen = false;
+    this.selected = false;
+  }
+
+  isSelected(): boolean {
+    return this.selected;
+  }
+
+  // event handlers
+
+  onToggleActionDropdown(event: MouseEvent): void {
+    event.stopPropagation();  
+    console.log("PRE " + this.workItem.id + " - " + this.actionDropdownOpen);
+    this.actionDropdownOpen = !this.actionDropdownOpen;
+    console.log("POST " + this.workItem.id + " - " + this.actionDropdownOpen);
+    // clicking on the action menu automatically selects the entry
+    this.selectEvent.emit(this);  
+  }
+
+  onDelete(event: MouseEvent): void {
+    event.stopPropagation();
+    this.workItemService
+      .delete(this.workItem)
+      .then(() => {
+        this.deleteEvent.emit(this);
+      });
+  }
+
+  onSelect(event: MouseEvent): void {
+    event.stopPropagation();
+    this.selectEvent.emit(this);    
+  }
+
+  onDetail(event: MouseEvent): void {
+    event.stopPropagation();
+    this.detailEvent.emit(this);
+  }
+
+  onMoveToBacklog(event: MouseEvent): void {
+    alert("NOT IMPLEMENTED YET.")
+  }
+
+  onChangeState(event: MouseEvent): void {
+    alert("NOT IMPLEMENTED YET.")
+  }
+}

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -1,62 +1,21 @@
 <app-header></app-header>
+
 <div class="container-fluid screen-min-ht">
 	<div class="list-group list-view-pf list-view-pf-view">
-		 <div>
-			 <div class="list-group-item supress-hover" (click)="addWorkItem()">
-				<work-item-quick-add (close)="close($event)"></work-item-quick-add>
-			</div>
-		</div>
-		<div *ngFor="let workItem of workItems">
-			<div class="list-group-item" (click)="onSelect(workItem)"
-					 [class.selected]="workItem === selectedWorkItem">
-				<div class="list-view-pf-actions">
-					<button class="btn btn-default" (click)="gotoDetail(workItem)">View Details</button>
-					<button class="btn btn-default delete-button" (click)="deleteWorkItem(workItem); $event.stopPropagation()">Delete</button>
-					<div class="dropdown pull-right dropdown-kebab-pf">
-						<button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-							<span class="fa fa-ellipsis-v"></span>
-						</button>
-						<ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">
-							<li><a href="#">Delete</a></li>
-							<li><a href="#">Move to backlog</a></li>
-							<li><a href="#">Change Status</a></li>
-						</ul>
-					</div>
-				</div>
-				<div class="list-view-pf-main-info">
-					<div class="list-view-pf-left">
-						<status-drawer [workItem]="workItem"></status-drawer>						
-					</div>
-					<div class="list-view-pf-left type">
-						<!--<span class='fa' [ngClass]="{'fa-bookmark': workItem.workItemType=='story', 'fa-bug':workItem.workItemType=='bug'}"></span>-->
-						<span class='fa' [ngClass]="{'fa-wrench': workItem.type=='system.bug',
-											'fa-user': workItem.type=='system.userstory',
-											'fa-globe': workItem.type=='system.feature',
-											'fa-bookmark': workItem.type=='system.experience',
-											'fa-eye': workItem.type=='system.experience',
-											'fa-bank': workItem.type=='system.fundamental',
-											'fa-rocket': workItem.type=='system.valueproposition' }">
-						</span>
-							{{workItem.id}}
-					</div>
-					<div class="list-view-pf-body">
-						<div class="list-view-pf-description">
-							<div class="list-group-item-heading">
-								{{workItem.fields['system.title']}}
-							</div>
-							<div class="list-group-item-text">
-								{{workItem.fields['system.description'] ? workItem.fields['system.description'] : "No description available for this work item."}}
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-			<!--<div *ngIf="workItem.isExpanded" class="work-item-details" >-->
-      			<!--{{workItem.name | uppercase}} - {{workItem.description}}-->
-				<!--<hr />-->
-      		<!--</div>-->
-		</div>
+    <div>
+		<div class="list-group-item supress-hover" (click)="addWorkItem()">
+      		<work-item-quick-add (close)="close($event)"></work-item-quick-add>
+    	</div>
+	</div>
+    <div>
+		<work-item-list-entry *ngFor="let workItem of workItems" 
+					[workItem]="workItem" 
+					(selectEvent)="onSelect($event)" 
+					(detailEvent)="onDetail($event)" 
+					(deleteEvent)="onDelete($event)">
+		</work-item-list-entry>
 	</div>
 </div>
 <div class="error" *ngIf="error">{{error}}</div>
+
 <app-footer></app-footer>

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -4,6 +4,7 @@ import { Router } from "@angular/router";
 import { Logger } from '../../shared/logger.service';
 import { WorkItem } from '../work-item';
 import { WorkItemService } from '../work-item.service';
+import { WorkItemListEntryComponent } from './work-item-list-entry.component';
 
 @Component({
   selector: 'work-item-list',
@@ -11,8 +12,9 @@ import { WorkItemService } from '../work-item.service';
   styleUrls: ['/work-item-list.component.scss'],
 })
 export class WorkItemListComponent implements OnInit {
+
   workItems: WorkItem[];
-  selectedWorkItem: WorkItem;
+  selectedWorkItemEntryComponent: WorkItemListEntryComponent;
   addingWorkItem = false;
 
   constructor(
@@ -21,7 +23,13 @@ export class WorkItemListComponent implements OnInit {
     private logger: Logger) {
   }
 
-  getWorkItems(): void {
+  ngOnInit(): void {
+    this.reloadWorkItems();
+  }
+
+  // model handlers
+
+  reloadWorkItems(): void {
     this.workItemService
       .getWorkItems()
       .then(workItems => this.workItems = workItems.reverse());
@@ -29,33 +37,34 @@ export class WorkItemListComponent implements OnInit {
 
   addWorkItem(): void {
     this.addingWorkItem = true;
-    this.selectedWorkItem = null;
+    this.selectedWorkItemEntryComponent = null;
   }
 
   close(savedWorkItem: WorkItem) {
     this.addingWorkItem = false;
-    if (savedWorkItem) { this.getWorkItems(); }
+    if (savedWorkItem) { this.reloadWorkItems(); }
   }
 
-  deleteWorkItem(workItem: WorkItem): void {
-    this.workItemService
-      .delete(workItem)
-      .then(() => {
-        this.workItems = this.workItems.filter(h => h !== workItem);
-        if (this.selectedWorkItem === workItem) { this.selectedWorkItem = null; }
-      });
+  // event handlers
+
+  onSelect(entryComponent: WorkItemListEntryComponent): void {
+    let workItem: WorkItem = entryComponent.getWorkItem();
+    // de-select prior selected element (if any)
+    if (this.selectedWorkItemEntryComponent && this.selectedWorkItemEntryComponent!=entryComponent)
+      this.selectedWorkItemEntryComponent.deselect();
+    // select new component
+    entryComponent.select();
+    this.selectedWorkItemEntryComponent = entryComponent;
   }
 
-  ngOnInit(): void {
-    this.getWorkItems();
+  onDetail(entryComponent: WorkItemListEntryComponent): void {
+    let workItem: WorkItem = entryComponent.getWorkItem();
+    // clicking on detail always also selects an entry
+    this.onSelect(entryComponent);
+    this.router.navigate(['/detail', workItem.id]);
   }
 
-  onSelect(workItem: WorkItem): void {
-    this.selectedWorkItem = workItem;
-  }
-
-  gotoDetail(workItem: WorkItem): void {
-    this.selectedWorkItem = workItem;
-    this.router.navigate(['/detail', this.selectedWorkItem.id]);
+  onDelete(entryComponent: WorkItemListEntryComponent): void {
+    this.reloadWorkItems();
   }
 }


### PR DESCRIPTION
Extracted the list entry as a seperate component, making it reusable and self-contained (child widgets like buttons/menus are now controlled from the list entry itself, not from the parent). Wiring up, cleaning the wiring a bit. Enabled dropdown menu on the list entries. Fixed the inmemory service to adhere to the api changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/68)
<!-- Reviewable:end -->
