### PR TITLE
Fix for #111 - display work item's title on the detail's page

### DIFF
--- a/src/app/work-item/work-item-detail/work-item-detail.component.html
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.html
@@ -1,7 +1,7 @@
 <app-header></app-header>
 <div class="container-fluid screen-min-ht">
   <div *ngIf="workItem" id="workItemDetail_Wrapper">
-  <h1>{{workItem.name}} Details</h1>
+  <h1>{{workItem.fields['system.title']}} Details</h1>
   <br />
   <div class="form-horizontal">
     <div class="form-group">


### PR DESCRIPTION
Work item's view details will be able to display the work item title in the details page.