### PR TITLE
Fixes #162 - provide context for webpack to allow system.js

### DIFF
--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -7,7 +7,9 @@ const helpers = require('./helpers');
 /**
  * Webpack Plugins
  */
+const webpack = require('webpack');
 const ProvidePlugin = require('webpack/lib/ProvidePlugin');
+const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
@@ -206,6 +208,18 @@ module.exports = {
       }
     }),
 
+    /**
+     * Plugin: ContextReplacementPlugin
+     * Description: Provides context to Angular's use of System.import
+     *
+     * See: https://webpack.github.io/docs/list-of-plugins.html#contextreplacementplugin
+     * See: https://github.com/angular/angular/issues/11580
+     */
+    new webpack.ContextReplacementPlugin(
+      // The (\\|\/) piece accounts for path separators in *nix and Windows
+      /angular(\\|\/)core(\\|\/)(esm(\\|\/)src|src)(\\|\/)linker/,
+      helpers.root('src') // location of your src
+    ),
 
   ],
 


### PR DESCRIPTION
Fixes #162 - provide context for webpack to allow Angular's use of system.import.