### PR TITLE
Fixes #134 - Make it easier to run the test.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,18 @@
 = ALMighty UI
 
+=== ALMighty UI is a currently an application planner and issue tracker front-end.
+It uses https://github.com/almighty/almighty-core[ALMighty-core] as the back-end.
+
 If this is the first time you are starting the UI you need to run
 
 ----
 $ npm install
+----
+
+If you trying to refresh your install you can run:
+
+----
+$ npm run reinstall
 ----
 
 Start the app by executing the following. 
@@ -12,31 +21,78 @@ Start the app by executing the following.
 $ npm start
 ----
 
-If you wish to run the app with the in-memory dataset, you need to set an environment 
+If you wish to run the app with the in-memory dataset, you need to set an environment
 variable "ENV" to "inmemory" and do a rebuild. The setting is stored inside the build, 
 changing the value back to unset or "development" (default for npm start) needs a rebuild
 to take effect.
 
+== Run All Checks
+
+To run the linter, build validator, unit tests, and functional test use:
+
+----
+$ npm test
+----
+
+
+== Lint
+
+To run the TypeScript and Angular 2 linter, use:
+
+----
+$ npm run lint
+----
+
+NOTE: They also run during the unit tests.
+
+== Build Validation
+
+To validate the webpack build, use:
+
+----
+$ npm run validate
+----
+
+NOTE: Validation also runs the unit tests.
+
 == Unit Tests
 
-Unit (UI) tests are automatically executed on the PR check process (using 
-`cico_run_tests.sh`) or on the release process (using `cico_build_deploy.sh`) but
-can also executed from the development environment by invoking the following command:
+To run the unit test, use:
+
+----
+$ npm run test:unit
+----
+
+To run the unit test in a watch mode so that they are rerun every time you save, use:
+
+----
+$ npm run watch:test
+----
+
+Unit (UI) tests are automatically executed on the PR(pull request) check process (using
+`cico_run_tests.sh`) or on the release process (using `cico_build_deploy.sh`). To executed
+these scripts from the development environment you can run the following script:
 
 ----
 ./run_unit_tests.sh
 ----
 
 For unit testing, Jasmine, Karma, Webpack is used. There are unit tests available for 
-both services and UI compnents. There are `.spec.ts` files available in individual 
-component or service folder. Karma and Webpack config is written inside config directry 
+both services and UI components. There are `.spec.ts` files available in individual
+component or service folder. Karma and Webpack config is written inside config directory
 under root.
 
 == Functional Tests
 
-Functional (UI) tests are automatically executed on the PR check process (using 
+To run the functional test, use:
+
+----
+$ npm run test:func
+----
+
+Functional (UI) tests are automatically executed on the PR check process (using
 `cico_run_tests.sh`) or on the release process (using `cico_build_deploy.sh`) but
-can also executed from the development environment by invoking the following command:
+can also be executed from the development environment by invoking the following command:
 
 ----
 ./run_functional_tests.sh
@@ -60,7 +116,7 @@ npm run build:prod
 
 The build output will be under `dist` directory.
 
-To create docker image, run this command immediatly after the previous command:
+To create docker image, run this command immediately after the previous command:
 
 ----
 docker build -t almighty-ui-deploy -f Dockerfile.deploy .

--- a/package.json
+++ b/package.json
@@ -36,15 +36,18 @@
     "prebuild": "npm run clean-and-copy",
     "prebuild:prod": "npm run clean-and-copy",
     "protractor": "sleep 15 && ./node_modules/protractor/bin/protractor protractor.config.js",
+    "reinstall": "rm -rf node_modules && npm cache clean && npm install",
     "setup": "npm install && npm run validate",
     "start": "webpack-dev-server --inline --progress --host 0.0.0.0 --port 8088",
-    "test": "karma start",
+    "test": "npm-run-all --serial validate test:func",
+    "test:func": "./run_functional_tests.sh",
+    "test:unit": "karma start",
     "testserver-start": "webpack-dev-server --inline --progress --host 0.0.0.0 --port 8088",
-    "validate": "npm-run-all --parallel validate-webpack:* test --serial check-coverage",
+    "validate": "npm-run-all --parallel validate-webpack:* test:unit --serial check-coverage",
     "validate-webpack:dev": "webpack-validator webpack.config.js --env.dev",
     "validate-webpack:prod": "webpack-validator webpack.config.js --env.prod",
     "webdriver-start": "./node_modules/protractor/bin/webdriver-manager update && ./node_modules/protractor/bin/webdriver-manager start",
-    "watch:test": "npm test -- --auto-watch --no-single-run"
+    "watch:test": "npm run test:unit -- --auto-watch --no-single-run"
   },
   "dependencies": {
     "@angular/common": "2.0.1",

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -5,7 +5,7 @@ echo Using logfile $LOGFILE
 
 # Running npm test
 echo Running unit tests...
-npm test | tee $LOGFILE ; UNIT_TEST_RESULT=${PIPESTATUS[0]}
+npm run test:unit | tee $LOGFILE ; UNIT_TEST_RESULT=${PIPESTATUS[0]}
 
 if [ $UNIT_TEST_RESULT -eq 0 ]; then
   echo 'Unit tests OK'


### PR DESCRIPTION
Fixes #134 - Make it easier to run the test. Update the README with instructions.

Now "npm test" will run every check we have. There are separate commands for each check and they are now explained in the README.