### PR TITLE
Add a confirmation dialog box to the work item veiw/detail page (#126)

### DIFF
--- a/src/app/work-item/work-item-detail/work-item-detail.component.html
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.html
@@ -1,4 +1,10 @@
 <alm-app-header></alm-app-header>
+<div *ngIf="showDialog">	
+	<pf-dialog
+		(pfDialogClick)="onButtonClick($event)"
+		[dialog]='dialog'	
+	></pf-dialog>
+</div>
 <div class="container-fluid screen-min-ht">
   <div *ngIf="workItem" id="workItemDetail_Wrapper">
     <h1>{{workItem.fields['system.title']}} Details</h1>
@@ -76,7 +82,7 @@
                 Save
               </button>
               <button type="button" id="workItemDetail_btn_back" class="btn btn-default"        
-                (click)="goBack()">Back</button>
+                (click)="goBack(almWorkItemDetailForm.form.dirty)">Back</button>
             </div>
           </div>
         </div>    

--- a/src/app/work-item/work-item-detail/work-item-detail.component.spec.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.spec.ts
@@ -17,6 +17,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { AlmTrim } from '../../pipes/alm-trim';
 import { Logger } from '../../shared/logger.service';
 
+import { Dialog } from '../../shared-component/dialog/dialog';
+import { DialogComponent } from '../../shared-component/dialog/dialog.component';
+
 import { FooterComponent } from '../../footer/footer.component';
 import { HeaderComponent } from '../../header/header.component';
 
@@ -29,12 +32,23 @@ describe('Detailed view and edit a selected work item - ', () => {
   let comp: WorkItemDetailComponent;
   let fixture: ComponentFixture<WorkItemDetailComponent>;
   let el: DebugElement;
+  let el1: DebugElement;
   let logger: Logger;
+
+  let dialog: Dialog;
 
   let fakeWorkItem: WorkItem;
   let fakeService: any;
 
   beforeEach(() => {
+    dialog = {
+      'title' : 'Changes have been made',
+      'message' : 'Do you want to discard your changes?',
+      'actionButtons': [
+        {'title': ' Discard', 'value': 1},
+        {'title': 'Cancel', 'value': 0}]
+    } as Dialog;
+
     fakeWorkItem = {
       'fields': {
         'system.assignee': 'me',
@@ -74,7 +88,8 @@ describe('Detailed view and edit a selected work item - ', () => {
         WorkItemDetailComponent,
         HeaderComponent,
         FooterComponent,
-        AlmTrim
+        AlmTrim,        
+        DialogComponent
       ],
       providers: [
         Logger,
@@ -255,7 +270,7 @@ describe('Detailed view and edit a selected work item - ', () => {
       expect(el.classes['btn-primary']).toBeFalsy();
     }));
 
-  it('Navigate when Back is clicked',
+  it('Navigate when Back is clicked without making any changes',
     inject([Location], fakeAsync((location: Location) => {
       spyOn(location, 'back');
       fixture.detectChanges();
@@ -264,6 +279,20 @@ describe('Detailed view and edit a selected work item - ', () => {
       tick();
       expect(location.back).toHaveBeenCalled();
     })));
+
+  it('Display confrimation dialog when Back is clicked after making changes',
+    inject([Location], fakeAsync((location: Location) => {
+      spyOn(location, 'back');
+      fixture.detectChanges();
+      comp.workItem = fakeWorkItem;
+      el1 = fixture.debugElement.query(By.css('#wi-detail-title'));
+      el1.nativeElement.value = 'User entered work item title';      
+      fixture.detectChanges();
+      tick();
+      comp.goBack(true);
+      expect(location.back).not.toHaveBeenCalled();
+    })));
+
 
   it('Navigate when work item form has been submitted and submit resolves',
     inject([Location], fakeAsync((location: Location) => {

--- a/src/app/work-item/work-item-detail/work-item-detail.component.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.ts
@@ -6,6 +6,9 @@ import { AlmTrim } from '../../pipes/alm-trim';
 
 import { Logger } from '../../shared/logger.service';
 
+import { Dialog } from '../../shared-component/dialog/dialog';
+import { DialogComponent } from '../../shared-component/dialog/dialog.component';
+
 import { WorkItem } from '../work-item';
 import { WorkItemService } from '../work-item.service';
 
@@ -23,8 +26,18 @@ export class WorkItemDetailComponent implements OnInit {
   // TODO: These should be read from the WorkitemType of the given Workitem
   workItemStates = ['new', 'in progress', 'resolved', 'closed'];
 
+  dialog: Dialog = {
+    'title' : 'Changes have been made',
+    'message' : 'Do you want to discard your changes?',
+    'actionButtons': [
+        {'title': ' Discard', 'value': 1},
+        {'title': 'Cancel', 'value': 0}]
+  };
+  showDialog: boolean = false;
+  
   submitted = false;
   active = true;
+
   
   constructor(
     private workItemService: WorkItemService,
@@ -53,12 +66,24 @@ export class WorkItemDetailComponent implements OnInit {
       this.workItemService
       .update(this.workItem)
       .then(() => 
-        this.goBack());
+        this.goBack(false));
     } 
   }
 
-  goBack(): void {
-    this.location.back();
+  goBack(change: boolean): void {
+    if (change == true){
+      this.showDialog = true;
+    }else{
+      this.location.back();
+    }    
+  }
+
+  onButtonClick(val: number): void{
+    if (val == 1){
+      this.goBack(false);
+    }else{
+      this.showDialog = false;
+    }
   }
 }
 


### PR DESCRIPTION
PR #186 needs to be merged first.

Task reference - #126 

Add a confirmation dialog on the work item's view/edit page which gets displayed if a user makes changes and clicks on back without saving the changes.