### PR TITLE
Logout event listener to avoid page reloading

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -23,6 +23,7 @@ export class AuthenticationService {
     if ('token' in params) {
       this.authToken = params['token'];
       localStorage.setItem('auth_token', this.authToken);
+      location.href = location.protocol + '//' + location.host;
       return true;
     }
     //this.router.navigate(['login']);
@@ -32,9 +33,9 @@ export class AuthenticationService {
   logout() {
     this.authToken = '';
     localStorage.removeItem('auth_token');
-    //this.router.navigate(['login']);
+    // this.router.navigate(['login']);
     this.broadcaster.broadcast('logout', 1);
-    location.href = location.protocol + '//' + location.host + location.pathname + location.hash;
+    // location.href = location.protocol + '//' + location.host + location.pathname + location.hash;
   }
 
   getToken() {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -5,6 +5,7 @@ import { Logger } from '../shared/logger.service';
 import { User } from '../user/user';
 import { UserService } from '../user/user.service';
 import { AuthenticationService } from '../auth/authentication.service';
+import { Broadcaster } from './../shared/broadcaster.service';
 
 @Component({
   selector: 'alm-app-header',
@@ -22,8 +23,8 @@ export class HeaderComponent implements OnInit {
     private router: Router,
     private userService: UserService,
     private logger: Logger,
-    private auth: AuthenticationService) {
-  }
+    private auth: AuthenticationService,
+    private broadcaster: Broadcaster) {}
 
   getLoggedUser(): void {
     if (this.auth.isLoggedIn()) {
@@ -42,12 +43,25 @@ export class HeaderComponent implements OnInit {
   }
 
   ngOnInit(): void {        
+    this.listenToEvents();
     this.getLoggedUser();
     this.loggedIn = this.auth.isLoggedIn();
   }
 
-  onImgLoad(){    
+  onImgLoad(){
     this.imgLoaded = true;
   }
 
+  resetData(): void {
+    this.loggedInUser = null as User;
+    this.loggedIn = false;
+    this.imgLoaded = false;
+  }
+  
+  listenToEvents() {
+    this.broadcaster.on<string>('logout')
+      .subscribe(message => {
+        this.resetData();
+    });
+  }
 }

--- a/src/app/work-item/work-item-detail/work-item-detail.component.spec.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.spec.ts
@@ -15,6 +15,7 @@ import { By }                  from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { AlmTrim } from '../../pipes/alm-trim';
+import { Broadcaster } from './../../shared/broadcaster.service';
 import { Logger } from '../../shared/logger.service';
 
 import { Dialog } from '../../shared-component/dialog/dialog';
@@ -120,6 +121,7 @@ describe('Detailed view and edit a selected work item - ', () => {
         DialogComponent
       ],
       providers: [
+        Broadcaster,
         Logger,
         Location,
         {

--- a/src/app/work-item/work-item-detail/work-item-detail.component.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Params } from '@angular/router';
 
 import { AlmTrim } from '../../pipes/alm-trim';
 import { AuthenticationService } from './../../auth/authentication.service';
+import { Broadcaster } from './../../shared/broadcaster.service';
 
 import { Logger } from '../../shared/logger.service';
 
@@ -42,6 +43,7 @@ export class WorkItemDetailComponent implements OnInit {
   
   constructor(
     private auth: AuthenticationService,
+    private broadcaster: Broadcaster,
     private workItemService: WorkItemService,
     private route: ActivatedRoute,
     private location: Location,
@@ -49,6 +51,7 @@ export class WorkItemDetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.listenToEvents();
     this.route.params.forEach((params: Params) => {
       if (params['id'] !== undefined) {
         let id = params['id'];
@@ -87,6 +90,13 @@ export class WorkItemDetailComponent implements OnInit {
     }else{
       this.showDialog = false;
     }
+  }
+
+  listenToEvents() {
+    this.broadcaster.on<string>('logout')
+      .subscribe(message => {
+        this.loggedIn = false;
+    });
   }
 }
 

--- a/src/app/work-item/work-item-list-entry/work-item-list-entry.component.ts
+++ b/src/app/work-item/work-item-list-entry/work-item-list-entry.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Router }                                         from '@angular/router';
 
 import { AuthenticationService } from './../../auth/authentication.service';
+import { Broadcaster } from './../../shared/broadcaster.service';
 import { Logger } from '../../shared/logger.service';
 
 import { Dialog }            from '../../shared-component/dialog/dialog';
@@ -51,12 +52,13 @@ export class WorkItemListEntryComponent implements OnInit {
   loggedIn: Boolean = false;
 
   constructor(private auth: AuthenticationService,
+              private broadcaster: Broadcaster,
               private router: Router,
               private workItemService: WorkItemService,
-              private logger: Logger) {
-  }
+              private logger: Logger) {}
 
   ngOnInit(): void {
+    this.listenToEvents();
     this.getOptions();
     this.loggedIn = this.auth.isLoggedIn();
   }
@@ -153,5 +155,12 @@ export class WorkItemListEntryComponent implements OnInit {
             this.workItem = updatedWorkItem;
           });
       });
+  }
+
+  listenToEvents() {
+    this.broadcaster.on<string>('logout')
+      .subscribe(message => {
+        this.loggedIn = false;
+    });
   }
 }

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router }            from '@angular/router';
 
 import { AuthenticationService } from './../../auth/authentication.service';
+import { Broadcaster } from './../../shared/broadcaster.service';
 import { Logger } from '../../shared/logger.service';
 
 import { WorkItem }                   from '../work-item';
@@ -23,12 +24,14 @@ export class WorkItemListComponent implements OnInit {
 
   constructor(
     private auth: AuthenticationService,
+    private broadcaster: Broadcaster,
     private router: Router,
     private workItemService: WorkItemService,
     private logger: Logger) {
   }
 
   ngOnInit(): void {
+    this.listenToEvents();
     this.reloadWorkItems();
     this.loggedIn = this.auth.isLoggedIn();
   }
@@ -84,5 +87,12 @@ export class WorkItemListComponent implements OnInit {
 
   onDelete(entryComponent: WorkItemListEntryComponent): void {
     this.reloadWorkItems();
+  }
+
+  listenToEvents() {
+    this.broadcaster.on<string>('logout')
+      .subscribe(message => {
+        this.loggedIn = false;
+    });
   }
 }


### PR DESCRIPTION
    - An event is broadcasted over logout
    - Listened through out the comonents
    - Update components accordingly on logout
    - Also removing token from the URL after login
            - Need to find a better way to do it, other than just
	      reloading the app to the base url.