### PR TITLE
Rerouted logging to stdout.

### DIFF
--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -11,14 +11,16 @@ echo -n Updating Webdriver and Selenium...
 node_modules/protractor/bin/webdriver-manager update
 # Start selenium server just for this test run
 echo -n Starting Webdriver and Selenium...
-(node_modules/protractor/bin/webdriver-manager start >>$LOGFILE 2>&1 &)
+#(node_modules/protractor/bin/webdriver-manager start >>$LOGFILE 2>&1 &)
+node_modules/protractor/bin/webdriver-manager start &
 # Wait for port 4444 to be listening connections
 while ! (ncat -w 1 127.0.0.1 4444 </dev/null >/dev/null 2>&1); do sleep 1; done
 echo done.
 
 # Start the web app
 echo -n Starting Almighty development server...
-(node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --progress --host 0.0.0.0 --port 8088 >>$LOGFILE 2>&1 &)
+#(node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --progress --host 0.0.0.0 --port 8088 >>$LOGFILE 2>&1 &)
+node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --progress --host 0.0.0.0 --port 8088 &
 # Wait for port 8088 to be listening connections
 while ! (ncat -w 1 127.0.0.1 8088 </dev/null >/dev/null 2>&1); do sleep 1; done
 echo done.


### PR DESCRIPTION
Logging for functional tests is now fully going to stdout.