### PR TITLE
Outline around description field is take care of. (fixes #278)

### DIFF
--- a/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.html
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.html
@@ -97,21 +97,21 @@
       </div>
       <div class="width100 pull-left">
         <div class="col-md-12 col-sm-12 col-xw-12 detail-description" *ngIf="loggedIn">
-          <div class="detail-desc-div-wrap">
-            <div class="detail-desc-div" [class.desc-active]="descEditable">                            
-            <p almEditable [editable]="descEditable"
-              #desc 
-              (onUpdate)="descUpdate($event)"
-              (keyup.enter)="onUpdateDescription()"
-              (keydown.enter)="preventDef($event)"
-              id="wi-detail-desc" 
-              class="description"
-              [innerHTML]="workItem.fields['system.description']">
-            </p>
-            </div>
-            <div class="edit-icon">
+          <div class="detail-desc-div-wrap" (click)="toggleDescription(false, true)">
+            <div class="detail-desc-div" [class.desc-editable]="descEditable">                            
+              <p almEditable [editable]="descEditable"
+                #desc 
+                (onUpdate)="descUpdate($event)"
+                (keydown.enter)="onUpdateDescription()"
+                (keyup.enter)="preventDef($event)"
+                id="wi-detail-desc" 
+                class="description"
+                [innerHTML]="workItem.fields['system.description']">
+              </p>
+              <div class="edit-icon">
                 <span id="workItemDesc_btn_edit" class="pficon-edit" 
                   (click)='toggleDescription()'></span>
+              </div>
             </div>
           </div>
         </div>
@@ -127,7 +127,7 @@
           </div>
           <div id="workItemdesc_btn_cancel" 
               class="fl btn-small pull-right detail-action-btn" 
-              (click)="toggleDescription()">
+              (click)="closeDescription()">
               <span class="fa fa-close"></span>
           </div>
       </div>

--- a/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.scss
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.scss
@@ -88,21 +88,29 @@
       background-color: $color-pf-black-150;
       .detail-desc-div {
         min-height: 50px;
-        border: 0.3px solid $color-pf-black-400;
-        background-clip: content-box;
         background-color: $color-pf-white;
         padding-right: 30px;
+        border: 0.3px solid $color-pf-white;
         p {
-          padding: 5px;
+          padding: 5px 10px;
+          margin: 0px;
           outline: 0px solid transparent;
         }
-      }
-      .edit-icon{
-        position: absolute;
-        right: 30px;
-        z-index: 10;
-        top: $pad10;
-        cursor: pointer;
+        .edit-icon {
+          display: none;
+          position: absolute;
+          right: 30px;
+          z-index: 10;
+          top: $pad10;
+          cursor: pointer;
+        }
+        &:hover {
+          background-clip: content-box;
+          border-color: $color-pf-black-400;
+          .edit-icon {
+            display: block;
+          }
+        }
       }
     }
   }
@@ -118,8 +126,16 @@
     background-color: #ebebeb;
     margin-left: $margin5;
   }
-  .desc-active {
+  .desc-editable {
     border: 0.6px solid $color-pf-blue-400 !important;
+    padding-right: 30px !important;
+    background-clip: content-box !important;
+    .edit-icon {
+      display: block !important;
+    }
+    p {
+      padding: 5px 10px !important;
+    }
   }
 }
 .wi-type-icon {

--- a/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.ts
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.ts
@@ -98,13 +98,24 @@ export class WorkItemDetailComponent implements OnInit {
     }
   }
 
-  toggleDescription(internal: Boolean = false): void{
+  toggleDescription(internal: Boolean = false, 
+                    onlyOpen: Boolean = false): void{
     if (this.headerEditable && !internal) {
       this.onUpdateTitle();
     }
     if (this.loggedIn) {
-      this.descEditable = !this.descEditable;
+      if (onlyOpen) {
+        this.descEditable = true;  
+      } else {
+        this.descEditable = !this.descEditable;
+      }
     }
+  }
+
+  closeDescription(): void {
+    this.description.nativeElement.innerHTML = 
+    this.workItem.fields['system.description']; 
+    this.descEditable = false;
   }
 
   getWorkItemTypes(): void {
@@ -195,7 +206,13 @@ export class WorkItemDetailComponent implements OnInit {
       } catch (x){
         event.returnValue = false; //IE
       }
-      this.closeDetails();
+      if (this.descEditable) {
+        this.closeDescription();
+      } else if (this.headerEditable) {
+        this.headerEditable = false;
+      } else {
+        this.closeDetails();
+      }
     }
   }
 }


### PR DESCRIPTION
- User hovers over the description.
- A border with that edit icon appears.
- Clicking on the box or the edit icon would make the border highlighted
with light blue.
- And user can edit.
- User can press ESC while editing to cancel or Enter to save.
- Pressing ESC twice will close the panel.