### PR TITLE
Fix quick add's description box's height on Firefox (#261)

### DIFF
--- a/src/app/work-item/work-item-quick-add/work-item-quick-add.component.scss
+++ b/src/app/work-item/work-item-quick-add/work-item-quick-add.component.scss
@@ -96,3 +96,10 @@
     }
   }
 }
+@-moz-document url-prefix() {
+  .workItemQuickAdd_story{
+    textarea.form-control {
+      max-height: 26px !important;
+    }
+  }
+}


### PR DESCRIPTION
Fix quick-add's description box's height on Firefox (#261).