### PR TITLE
Fix quick add's description box's height on Firefox (#261)

### DIFF
--- a/src/app/work-item/work-item-quick-add/work-item-quick-add.component.ts
+++ b/src/app/work-item/work-item-quick-add/work-item-quick-add.component.ts
@@ -23,7 +23,7 @@ export class WorkItemQuickAddComponent implements OnInit {
   showQuickAddBtn: Boolean;
   initialDescHeight: number = 0;
   initialDescHeightDiff: number = 0;
-  descHeight: any = 'inherit';
+  descHeight: any = '26px';
   descResize: any = 'none';
   
   constructor(
@@ -67,7 +67,7 @@ export class WorkItemQuickAddComponent implements OnInit {
           this.goBack(workItem);
           this.showQuickAddBtn = false;
           this.showQuickAdd = true;
-          this.descHeight = this.initialDescHeight ? this.initialDescHeight : 'inherit';
+          this.descHeight = this.initialDescHeight ? this.initialDescHeight : '26px';
           this.qaTitle.nativeElement.focus();
         })
         .catch(error => this.error = error); // TODO: Display error message


### PR DESCRIPTION
Fix quick add's description box's height on Firefox (#261)

The prior fix breaks the description box's height setting functionality. When a user enters long description text, the description box needs to increase in height accordingly.
This PR will solve #261 and retain the detail text sizing.