### PR TITLE
Make font awesome work on demo.almighty.io

### DIFF
--- a/src/assets/stylesheets/dropdowns.scss
+++ b/src/assets/stylesheets/dropdowns.scss
@@ -18,7 +18,7 @@
   border-top:   $caret-width-base solid \9; // IE8
   border-right: $caret-width-base solid transparent;
   border-left:  $caret-width-base solid transparent;
-  font-family: fontawesome-webfont;
+  font-family: $icon-font-name-fa;
   height: 9px; 
   position: relative;
   width: 12px; 

--- a/src/assets/stylesheets/variables.scss
+++ b/src/assets/stylesheets/variables.scss
@@ -38,7 +38,7 @@ $footer-pf-padding-top:                                             10px !defaul
 $footer-pf-height:                                                  37px !default;
 $gray-light-pf:                                                     $color-pf-black-400 !default;
 $gray-pf:                                                           $color-pf-black-700 !default;
-$icon-font-name-fa:                                                 "fontawesome-webfont" !default;
+$icon-font-name-fa:                                                 "FontAwesome" !default;
 $icon-font-name-pf:                                                 "PatternFlyIcons-webfont" !default;
 $icon-prefix:                                                       pficon !default;
 $img-bg-login:                                                      "bg-login.jpg" !default;


### PR DESCRIPTION
Make font awesome work on demo.almighty.io
Renamed the icon-font-name-fa, in https://github.com/nimishamukherjee/almighty-ui/blob/alm-ui-353/src/assets/stylesheets/variables.scss, to FontAwesome.

This is in line with https://github.com/patternfly/patternfly/blob/master/src/less/variables.less
