### PR TITLE
Set autofocus to Quick Add Input Field

### DIFF
--- a/src/app/work-item/work-item-quick-add/work-item-quick-add.component.ts
+++ b/src/app/work-item/work-item-quick-add/work-item-quick-add.component.ts
@@ -15,7 +15,7 @@ export class WorkItemQuickAddComponent implements OnInit {
   @Output() close = new EventEmitter();
   @ViewChild('quickAddTitle') qaTitle: any;
   @ViewChild('quickAddDesc') qaDesc: any;
-
+  
   error: any = false;
   workItem: WorkItem;
   validTitle: Boolean;
@@ -105,8 +105,10 @@ export class WorkItemQuickAddComponent implements OnInit {
       this.workItem.fields['system.title'] = '';
       this.validTitle = false;
       this.descHeight = this.initialDescHeight ? this.initialDescHeight : 'inherit';
+    } else {
+      setTimeout(() => this.qaTitle.nativeElement.focus());
     }
-  }
+}
 
   preventDef(event: any) {
     event.preventDefault();


### PR DESCRIPTION
When a user clicks 'Add Work Item', it focus on the Title input.