### PR TITLE
Prevent freezing if the target Workitem is not found

### DIFF
--- a/src/app/work-item/work-item-list/work-item-detail/work-item-link/work-item-link.component.html
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-link/work-item-link.component.html
@@ -64,13 +64,15 @@
                             <span *ngFor='let links of workitemLinks'>
                                 <!-- need to fina a way to store pipe result to a variable, isnstead of accessing pipe everytime -->
                                 <li *ngIf="links | almLinkTarget:workItem:linkType" class="link-list-group-list-item" [id]="links['id']">
-                                    <div (click)="onDetail(links, workItem)">
-                                        <span [id]="links['id'] + '-text'" class="col-md-8 col-sm-8 col-xs-8 truncate" >{{workItemsMap[links | almLinkTarget:workItem:linkType].id}} {{workItemsMap[links | almLinkTarget:workItem:linkType].fields['system.title']}}</span>
-                                        <span class="col-md-3 col-sm-3 col-xs-3">{{workItemsMap[links | almLinkTarget:workItem:linkType].fields['system.state']}}</span>
+                                    <div *ngIf="showWorkItem(links)">
+                                        <div (click)="onDetail(links, workItem)">
+                                            <span [id]="links['id'] + '-text'" class="col-md-8 col-sm-8 col-xs-8 truncate" >{{workItemsMap[links | almLinkTarget:workItem:linkType].id}} {{workItemsMap[links | almLinkTarget:workItem:linkType].fields['system.title']}}</span>
+                                            <span class="col-md-3 col-sm-3 col-xs-3">{{workItemsMap[links | almLinkTarget:workItem:linkType].fields['system.state']}}</span>
+                                        </div>
+                                        <a *ngIf="loggedIn" class="col-md-1 col-sm-1 col-xs-1" (click)="deleteLink(links)">
+                                            <i class="pull-right pficon pficon-close list-close-icon"></i>
+                                        </a>
                                     </div>
-                                    <a *ngIf="loggedIn" class="col-md-1 col-sm-1 col-xs-1" (click)="deleteLink(links)">
-                                        <i class="pull-right pficon pficon-close list-close-icon"></i>
-                                    </a>
                                 </li>
                             </span>
                         </ul>

--- a/src/app/work-item/work-item-list/work-item-detail/work-item-link/work-item-link.component.ts
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-link/work-item-link.component.ts
@@ -157,7 +157,7 @@ export class WorkItemLinkComponent implements OnInit, OnChanges {
             const sourceId = linkObj['relationships']['source']['data']['id'];
             const targetId = linkObj['relationships']['target']['data']['id'];
             const linkTypeId = linkObj['relationships']['link_type']['data']['id'];
-            if (this.workItem['id'] == sourceId || this.workItem['id'] == targetId) {
+            if (this.workItem['id'] == sourceId || this.workItem['id'] == targetId && (this.workItemsMap[sourceId] || this.workItemsMap[targetId])) {
                 this.totalLinks = this.totalLinks + 1;
                 if (!this.linksGroupCount.hasOwnProperty(linkTypeId)) {
                     this.linksGroupCount[linkTypeId] = 1;
@@ -186,6 +186,15 @@ export class WorkItemLinkComponent implements OnInit, OnChanges {
             workItemId = links['relationships']['source']['data']['id'];
         }
         this.router.navigate(['/work-item-list/detail/' + workItemId]);
+    }
+
+    showWorkItem(link: Link) {
+        const sourceId = link['relationships']['source']['data']['id'];
+        const targetId = link['relationships']['target']['data']['id'];
+        if (this.workItemsMap[sourceId] || this.workItemsMap[targetId]) {
+            return true;
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
Changes to prevent freezing of the screen if the target Workitem is not found while displaying the workitem links