### PR TITLE
Prevent freezing if the target Workitem is not found

### DIFF
--- a/src/app/work-item/work-item-list/work-item-detail/work-item-link/work-item-link.component.html
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-link/work-item-link.component.html
@@ -64,7 +64,7 @@
                             <span *ngFor='let links of workitemLinks'>
                                 <!-- need to fina a way to store pipe result to a variable, isnstead of accessing pipe everytime -->
                                 <li *ngIf="links | almLinkTarget:workItem:linkType" class="link-list-group-list-item" [id]="links['id']">
-                                    <div *ngIf="showWorkItem(links)">
+                                    <div *ngIf="showWorkItem(links, workItem)">
                                         <div (click)="onDetail(links, workItem)">
                                             <span [id]="links['id'] + '-text'" class="col-md-8 col-sm-8 col-xs-8 truncate" >{{workItemsMap[links | almLinkTarget:workItem:linkType].id}} {{workItemsMap[links | almLinkTarget:workItem:linkType].fields['system.title']}}</span>
                                             <span class="col-md-3 col-sm-3 col-xs-3">{{workItemsMap[links | almLinkTarget:workItem:linkType].fields['system.state']}}</span>

--- a/src/app/work-item/work-item-list/work-item-detail/work-item-link/work-item-link.component.ts
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-link/work-item-link.component.ts
@@ -188,13 +188,16 @@ export class WorkItemLinkComponent implements OnInit, OnChanges {
         this.router.navigate(['/work-item-list/detail/' + workItemId]);
     }
 
-    showWorkItem(link: Link) {
+    showWorkItem(link: Link, workItem: WorkItem) {
         const sourceId = link['relationships']['source']['data']['id'];
         const targetId = link['relationships']['target']['data']['id'];
-        if (this.workItemsMap[sourceId] || this.workItemsMap[targetId]) {
+        if (this.workItem['id'] == sourceId && this.workItemsMap[targetId]) {
             return true;
+        } else if (this.workItem['id'] == targetId && this.workItemsMap[sourceId]) {
+            return true;
+        } else {
+            return false;
         }
-        return false;
     }
 
 }


### PR DESCRIPTION
Changes to prevent freezing of the screen if the target Workitem is not found while displaying the workitem links.

check if source/target is their in workitem list.