### PR TITLE
Move onDetail to same level as onSelect in WorkItemList

### DIFF
--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
@@ -4,9 +4,9 @@
 		[dialog]='dialog'	
 	></pf-dialog>
 </div>
-<div class="list-group-item" (click)="onSelect($event)" [class.selected]="isSelected()">
+<div class="list-group-item" (click)="onDetail($event)" (click)="onSelect($event)" [class.selected]="isSelected()">
 	<!-- info area -->
-	<div class="list-view-pf-main-info" (click)="onDetail($event)">
+	<div class="list-view-pf-main-info">
 		<div class="list-view-pf-left type workItemList_workItemType">
 			<span almIcon [iconType]="workItem.fields['system.state']" class="color-grey pull-left"></span>
       		<span almIcon [iconType]="workItem.type" class="color-grey pull-left"></span>


### PR DESCRIPTION
Avoids abillity to 'select' the workitem but not actually trigger
the 'open' event

Fixes #422