### PR TITLE
Some of the first tests written depend on the in-memory count of 14 w…

### DIFF
--- a/src/tests/work-item/work-item-list/assign.spec.js
+++ b/src/tests/work-item/work-item-list/assign.spec.js
@@ -18,7 +18,7 @@ var WorkItemListPage = require('./page-objects/work-item-list.page'),
   testSupport = require('./testSupport');
 
 describe('Work item list', function () {
-  var page, items, startCount, browserMode;
+  var page, items, browserMode;
 
 var until = protractor.ExpectedConditions;
 var waitTime = 30000;
@@ -26,7 +26,6 @@ var waitTime = 30000;
   beforeEach(function () {
     testSupport.setBrowserMode('phone');
     page = new WorkItemListPage(true);
-    page.allWorkItems.count().then(function(originalCount) { startCount = originalCount; });
   });
 /**Test searching user in the assignee drop down  */
   it('Test searching user in the assignee drop down -phone ', function() {

--- a/src/tests/work-item/work-item-list/displayAndUpdateWorkItemDetails.spec.js
+++ b/src/tests/work-item/work-item-list/displayAndUpdateWorkItemDetails.spec.js
@@ -18,7 +18,7 @@ var WorkItemListPage = require('./page-objects/work-item-list.page'),
   testSupport = require('./testSupport');
 
 describe('Work item list', function () {
-  var page, items, startCount, browserMode;
+  var page, items, browserMode;
 
 var until = protractor.ExpectedConditions;
 var waitTime = 30000;
@@ -26,7 +26,6 @@ var waitTime = 30000;
   beforeEach(function () {
     testSupport.setBrowserMode('phone');
     page = new WorkItemListPage(true);
-    page.allWorkItems.count().then(function(originalCount) { startCount = originalCount; });
   });
 
 /* Create a new workitem, fill in the details, save, retrieve, update, save, verify updates are saved */

--- a/src/tests/work-item/work-item-list/displayWorkItemList.spec.js
+++ b/src/tests/work-item/work-item-list/displayWorkItemList.spec.js
@@ -19,12 +19,11 @@ var WorkItemListPage = require('./page-objects/work-item-list.page'),
   WorkItemDetailPage = require('./page-objects/work-item-detail.page');
 
 describe('Work item list', function () {
-  var page, items, startCount, browserMode;
+  var page, items, browserMode;
 
   beforeEach(function () {
     testSupport.setBrowserMode('phone');
     page = new WorkItemListPage(true);    
-    page.allWorkItems.count().then(function(originalCount) { startCount = originalCount; });
     
     workItemMockData = {
       pageTitle:'Some Title 14 Details',
@@ -35,10 +34,6 @@ describe('Work item list', function () {
       workItemAssignee:'someUser14',
       workItemState:'new'
     }; 
-  });
-
-  it('should contain 14 items.', function() {
-    expect(page.allWorkItems.count()).toBe(startCount);
   });
 
   it('should have the right mock data in the first entry - phone.', function() {
@@ -54,7 +49,6 @@ describe('Work item list', function () {
     page.clickWorkItemQuickAdd();
     page.typeQuickAddWorkItemTitle('Some Title');
     page.clickQuickAddSave().then(function() {
-      expect(page.allWorkItems.count()).toBe(startCount + 1);
       expect(page.workItemTitle(page.firstWorkItem)).toBe('Some Title');
       expect(page.workItemTitle(page.workItemByNumber(0))).toBe('Some Title');
     });
@@ -65,7 +59,6 @@ describe('Work item list', function () {
     page.clickWorkItemQuickAdd();
     page.typeQuickAddWorkItemTitle('Some Title');
     page.clickQuickAddSave().then(function() {
-      expect(page.allWorkItems.count()).toBe(startCount + 1);
       expect(page.workItemTitle(page.firstWorkItem)).toBe('Some Title');
       expect(page.workItemTitle(page.workItemByNumber(0))).toBe('Some Title');
     });

--- a/src/tests/work-item/work-item-list/quickadd-workitem.spec.js
+++ b/src/tests/work-item/work-item-list/quickadd-workitem.spec.js
@@ -18,7 +18,7 @@ var WorkItemListPage = require('./page-objects/work-item-list.page'),
   testSupport = require('./testSupport');
 
 describe('Work item list', function () {
-  var page, items, startCount, browserMode;
+  var page, items, browserMode;
 
   beforeEach(function () {
     testSupport.setBrowserMode('phone');

--- a/src/tests/work-item/work-item-list/unauthorizeduser.spec.js
+++ b/src/tests/work-item/work-item-list/unauthorizeduser.spec.js
@@ -23,7 +23,7 @@ var WorkItemListPage = require('./page-objects/work-item-list.page'),
   testSupport = require('./testSupport');
 
 describe('Work item list', function () {
-  var page, items, startCount, browserMode,detailPage;
+  var page, items, browserMode,detailPage;
 
   beforeEach(function () {
     testSupport.setBrowserMode('phone');

--- a/src/tests/work-item/work-item-list/work-item-list.spec.js
+++ b/src/tests/work-item/work-item-list/work-item-list.spec.js
@@ -17,12 +17,11 @@ var WorkItemListPage = require('./page-objects/work-item-list.page'),
   WorkItemDetailPage = require('./page-objects/work-item-detail.page');
 
 describe('Work item list', function () {
-  var page, items, startCount, browserMode;
+  var page, items, browserMode;
 
   beforeEach(function () {
     testSupport.setBrowserMode('phone');
     page = new WorkItemListPage(true);    
-    page.allWorkItems.count().then(function(originalCount) { startCount = originalCount; });
     
     workItemMockData = {
       pageTitle:'Some Title 14 Details',
@@ -33,11 +32,6 @@ describe('Work item list', function () {
       workItemAssignee:'someUser14',
       workItemState:'New'
     }; 
-  });
-
-
-  it('should contain 14 items.', function() {
-    expect(page.allWorkItems.count()).toBe(startCount);
   });
 
   it('should have the right mock data in the first entry - phone.', function() {
@@ -53,7 +47,6 @@ describe('Work item list', function () {
     page.clickWorkItemQuickAdd();
     page.typeQuickAddWorkItemTitle('Some Title');
     page.clickQuickAddSave().then(function() {
-      expect(page.allWorkItems.count()).toBe(startCount + 1);
       expect(page.workItemTitle(page.firstWorkItem)).toBe('Some Title');
       expect(page.workItemTitle(page.workItemByNumber(0))).toBe('Some Title');
     });
@@ -64,7 +57,6 @@ describe('Work item list', function () {
     page.clickWorkItemQuickAdd();
     page.typeQuickAddWorkItemTitle('Some Title');
     page.clickQuickAddSave().then(function() {
-      expect(page.allWorkItems.count()).toBe(startCount + 1);
       expect(page.workItemTitle(page.firstWorkItem)).toBe('Some Title');
       expect(page.workItemTitle(page.workItemByNumber(0))).toBe('Some Title');
     });


### PR DESCRIPTION
…ork items - these tests should be removed and should eventually be replaced with query tests for numbers of work items that match queries.