### PR TITLE
Fix hover behaviour of the title's edit icon, during dialogue based work item creation.

### DIFF
--- a/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.html
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.html
@@ -30,7 +30,7 @@
             id="title-click-div">
               <h2 *ngIf="!loggedIn" id="wi-detail-title-ne" class="detail-title truncate">{{ workItem.attributes['system.title'] }}</h2>
               <h2 *ngIf="loggedIn" id="wi-detail-title-click" class="detail-title truncate">{{ workItem.attributes['system.title'] }}</h2>
-              <span *ngIf="loggedIn" 
+              <span *ngIf="loggedIn && workItem.id" 
                 class="pficon-edit marginL10 fl detail-title-edit-ico" 
                 id="workItemTitle_btn_edit"></span>
           </div>


### PR DESCRIPTION
Fix hover behaviour of the title's edit icon, during dialogue based work item creation - the edit icon will not be shown on hover over the title input field (#540).