### PR TITLE
Validates WI title/desc datatypes and values, fixes #530

### DIFF
--- a/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.html
+++ b/src/app/work-item/work-item-list/work-item-detail/work-item-detail.component.html
@@ -193,11 +193,10 @@
                 id="wi-detail-desc" 
                 class="description"
                 [innerText]="
-                  workItem.attributes['system.description'] ? 
+                  !!workItem.attributes['system.description'] ?
                     workItem.attributes['system.description'] : 
                     descEditable ? 
-                      workItem.attributes['system.description'] : 
-                      'Work item description.'">
+                      '' : 'Work item description.'">
               </p>
               <div class="edit-icon">
                 <span id="workItemDesc_btn_edit" class="pficon-edit" 

--- a/src/app/work-item/work-item-quick-add/work-item-quick-add.component.ts
+++ b/src/app/work-item/work-item-quick-add/work-item-quick-add.component.ts
@@ -79,12 +79,20 @@ export class WorkItemQuickAddComponent implements OnInit, AfterViewInit {
 
   save(event: any = null): void {
     if (event) event.preventDefault();
-    if (this.workItem.attributes['system.title'] != null) {
-      this.workItem.attributes['system.title'] = this.workItem.attributes['system.title'].trim();
-    }
-    if (this.workItem.attributes['system.description'] != null) {
-      this.workItem.attributes['system.description'] = this.workItem.attributes['system.description'].trim();
-    }
+
+    // Do we have a real title?
+    // If yes, trim; if not, reassign it as a (blank) string.
+    this.workItem.attributes['system.title'] =
+      (!!this.workItem.attributes['system.title']) ?
+        this.workItem.attributes['system.title'].trim() : "";
+
+    // Same treatment as title, but this is more important.
+    // As we're validating title in the next step
+    // But passing on description as is (causing data type issues)
+    this.workItem.attributes['system.description'] =
+      (!!this.workItem.attributes['system.description']) ?
+        this.workItem.attributes['system.description'].trim() : "";
+
     if (this.workItem.attributes['system.title']) {
       this.workItemService
         .create(this.workItem)


### PR DESCRIPTION
- Makes the template display blank text for falsy values of `description`
- Avoids creating WI with `null` type descriptions form quick-add
  - Updated the validator for both title and descriptions
  - Reassign description as "" if no value was provided (i.e. null)

Signed-off-by: Soumya Deb <debloper@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-ui/591)
<!-- Reviewable:end -->
